### PR TITLE
fix: rename VERSION variable to NVIM_VERSION for clarity

### DIFF
--- a/src/neovim/install.sh
+++ b/src/neovim/install.sh
@@ -8,9 +8,9 @@ install_debian_dependencies() {
   rm -rf /var/lib/apt/lists/*
 }
 
-VERSION=${VERSION:-stable}
+NVIM_VERSION=${VERSION:-stable}
 
-echo "Activating feature 'neovim' ${VERSION}"
+echo "Activating feature 'neovim' ${NVIM_VERSION}"
 
 if [ "$(id -u)" -ne 0 ]; then
   echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
@@ -38,9 +38,9 @@ case "${ADJUSTED_ID}" in
   ;;
 esac
 
-echo "Downloading source for ${VERSION}..."
+echo "Downloading source for ${NVIM_VERSION}..."
 
-curl -o /tmp/nvim-linux-x86_64.tar.gz -L "https://github.com/neovim/neovim/releases/download/${VERSION}/nvim-linux-x86_64.tar.gz"
+curl -o /tmp/nvim-linux-x86_64.tar.gz -L "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/nvim-linux-x86_64.tar.gz"
 
 echo "Extracting..."
 


### PR DESCRIPTION
Update the install script to use NVIM_VERSION instead of VERSION for 
better clarity. This change ensures consistency in variable naming 
when activating features and downloading the source, improving 
readability and maintainability of the script.