### PR TITLE
fix(install): remove redundant profile source command

### DIFF
--- a/src/neovim/install.sh
+++ b/src/neovim/install.sh
@@ -53,9 +53,6 @@ if ! grep -q 'export PATH=$PATH:/usr/local/nvim-linux-x86_64/bin' ~/.profile; th
   echo 'export PATH=$PATH:/usr/local/nvim-linux-x86_64/bin' >>~/.profile
 fi
 
-# Nguồn lại profile để áp dụng thay đổi
-source ~/.profile
-
 # Xác minh cài đặt
 nvim -v
 

--- a/src/neovim/install.sh
+++ b/src/neovim/install.sh
@@ -54,6 +54,6 @@ if ! grep -q 'export PATH=$PATH:/usr/local/nvim-linux-x86_64/bin' ~/.profile; th
 fi
 
 # Xác minh cài đặt
-nvim -v
+/usr/local/nvim-linux-x86_64/bin/nvim --headless +PlugInstall +qall
 
 rm /tmp/nvim-linux-x86_64.tar.gz


### PR DESCRIPTION
Eliminate the unnecessary command to source the profile after 
updating the PATH. This simplifies the installation script and 
prevents potential issues with environment variable updates.