### PR TITLE
fix: update Neovim version and installation command

### DIFF
--- a/src/neovim/devcontainer-feature.json
+++ b/src/neovim/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Neovim",
   "id": "neovim",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Neovim Download Latest Version",
   "options": {
     "version": {

--- a/src/neovim/install.sh
+++ b/src/neovim/install.sh
@@ -54,6 +54,6 @@ if ! grep -q 'export PATH=$PATH:/usr/local/nvim-linux-x86_64/bin' ~/.profile; th
 fi
 
 # Xác minh cài đặt
-/usr/local/nvim-linux-x86_64/bin/nvim --headless +PlugInstall +qall
+/usr/local/nvim-linux-x86_64/bin/nvim --headless +"Lazy! sync" +qa
 
 rm /tmp/nvim-linux-x86_64.tar.gz


### PR DESCRIPTION
Bump Neovim version to 1.0.1 in the devcontainer feature file.  
Change the installation command in the script to use "Lazy! sync"  
instead of "+PlugInstall" for better plugin management.